### PR TITLE
Add API endpoint for fetching invitees with fallback

### DIFF
--- a/client/components/arcon/SendInviteDialog.tsx
+++ b/client/components/arcon/SendInviteDialog.tsx
@@ -93,6 +93,31 @@ export default function SendInviteDialog({
 }: SendInviteDialogProps) {
   const [activeTab, setActiveTab] = useState<"select" | "bulk">("select");
   const [employees, setEmployees] = useState<Employee[]>(SAMPLE_EMPLOYEES);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    let isMounted = true;
+    const controller = new AbortController();
+
+    async function loadInvitees() {
+      try {
+        const res = await fetch("/api/invitees", { signal: controller.signal });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data: { employees: Employee[] } = await res.json();
+        if (isMounted && Array.isArray(data.employees)) {
+          setEmployees(data.employees);
+        }
+      } catch (_err) {
+        // Keep static fallback if API fails
+      }
+    }
+
+    loadInvitees();
+    return () => {
+      isMounted = false;
+      controller.abort();
+    };
+  }, [isOpen]);
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedDepartments, setSelectedDepartments] = useState<string[]>([]);
   const [selectAll, setSelectAll] = useState(false);

--- a/client/components/arcon/SendInviteDialog.tsx
+++ b/client/components/arcon/SendInviteDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { X, Search, Filter, Download, Upload, Check } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";

--- a/server/index.ts
+++ b/server/index.ts
@@ -2,6 +2,7 @@ import "dotenv/config";
 import express from "express";
 import cors from "cors";
 import { handleDemo } from "./routes/demo";
+import { handleGetInvitees } from "./routes/invitees";
 
 export function createServer() {
   const app = express();
@@ -18,6 +19,9 @@ export function createServer() {
   });
 
   app.get("/api/demo", handleDemo);
+
+  // Invitees (static for now, to be replaced by DB-backed data)
+  app.get("/api/invitees", handleGetInvitees);
 
   return app;
 }

--- a/server/routes/invitees.ts
+++ b/server/routes/invitees.ts
@@ -1,0 +1,65 @@
+import { RequestHandler } from "express";
+import { Invitee, InviteesResponse } from "@shared/api";
+
+// Static data for now; later to be replaced by DB fetch
+const SAMPLE_INVITEES: Invitee[] = [
+  {
+    id: "1",
+    name: "Roger G. Rhone",
+    email: "RogerGRhone@teleworm.us",
+    initials: "OP",
+    avatarColor: "#F4DEE4",
+    department: "Operations",
+    selected: true,
+  },
+  {
+    id: "2",
+    name: "Mike J. Torres",
+    email: "MikeJTorres@rhyta.com",
+    initials: "MT",
+    avatarColor: "#D6ECF5",
+    department: "IT & Security",
+    selected: false,
+  },
+  {
+    id: "3",
+    name: "Wanda C. Moore",
+    email: "WandaCMoore@dayrep.com",
+    initials: "WM",
+    avatarColor: "#E0DAEE",
+    department: "Marketing",
+    selected: false,
+  },
+  {
+    id: "4",
+    name: "Roy C. Kephart",
+    email: "RoyCKephart@dayrep.com",
+    initials: "RK",
+    avatarColor: "#FFE6DE",
+    department: "Sales",
+    selected: true,
+  },
+  {
+    id: "5",
+    name: "Lois S. Spencer",
+    email: "LoisSSpencer@rhyta.com",
+    initials: "LS",
+    avatarColor: "#DAE5E6",
+    department: "Finance",
+    selected: false,
+  },
+  {
+    id: "6",
+    name: "Jerry T. Beavers",
+    email: "JerryTBeavers@teleworm.us",
+    initials: "JB",
+    avatarColor: "#F4EBE8",
+    department: "Human Resources",
+    selected: false,
+  },
+];
+
+export const handleGetInvitees: RequestHandler = (_req, res) => {
+  const response: InviteesResponse = { employees: SAMPLE_INVITEES };
+  res.json(response);
+};

--- a/shared/api.ts
+++ b/shared/api.ts
@@ -10,3 +10,17 @@
 export interface DemoResponse {
   message: string;
 }
+
+export interface Invitee {
+  id: string;
+  name: string;
+  email: string;
+  initials: string;
+  avatarColor: string;
+  department: string;
+  selected: boolean;
+}
+
+export interface InviteesResponse {
+  employees: Invitee[];
+}


### PR DESCRIPTION
## Purpose

Prepare the invite system for database integration by creating an API endpoint to fetch invitees. Currently uses static data as a placeholder, but establishes the infrastructure for future database-backed invitee retrieval in both send invites and bulk invites functionality.

## Code changes

- **Client**: Added `useEffect` hook in `SendInviteDialog.tsx` to fetch invitees from `/api/invitees` endpoint when dialog opens, with proper cleanup and fallback to static data on API failure
- **Server**: Created new `/api/invitees` endpoint in `server/index.ts` and corresponding route handler in `server/routes/invitees.ts` 
- **Types**: Added `Invitee` and `InviteesResponse` interfaces in `shared/api.ts` for type safety
- **Data**: Moved sample employee data to server-side as static placeholder for future database integration

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 47`

🔗 [Edit in Builder.io](https://builder.io/app/projects/bc759bfe4fe3463a894b46a4f552fd73/aura-home)

👀 [Preview Link](https://bc759bfe4fe3463a894b46a4f552fd73-aura-home.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>bc759bfe4fe3463a894b46a4f552fd73</projectId>-->
<!--<branchName>aura-home</branchName>-->