### PR TITLE
Fix React hooks order error in SendInviteDialog

### DIFF
--- a/client/components/arcon/SendInviteDialog.tsx
+++ b/client/components/arcon/SendInviteDialog.tsx
@@ -127,9 +127,7 @@ export default function SendInviteDialog({
   const uploadIntervalRef = useRef<number | null>(null);
   const [showFilterDropdown, setShowFilterDropdown] = useState(false);
 
-  if (!isOpen) return null;
-
-  // Ensure we clear any running interval when component unmounts or dialog closes
+  // Ensure we clear any running interval when component unmounts
   useEffect(() => {
     return () => {
       if (uploadIntervalRef.current) {
@@ -138,6 +136,16 @@ export default function SendInviteDialog({
       }
     };
   }, []);
+
+  // Also clear when dialog closes
+  useEffect(() => {
+    if (!isOpen && uploadIntervalRef.current) {
+      clearInterval(uploadIntervalRef.current);
+      uploadIntervalRef.current = null;
+    }
+  }, [isOpen]);
+
+  if (!isOpen) return null;
 
   const filteredEmployees = employees.filter((emp) => {
     const matchesSearch =


### PR DESCRIPTION
## Purpose
Fix the "Rendered more hooks than during the previous render" error in SendInviteDialog component that was preventing the save and send invites dialog from displaying properly. The user reported that the dialog was not visible due to React detecting a change in the order of hooks being called.

## Code changes
- Moved the early return `if (!isOpen) return null;` to after all hook declarations to ensure hooks are called in consistent order
- Split the cleanup logic into two separate `useEffect` hooks:
  - One for component unmount cleanup (existing logic)
  - One for dialog close cleanup (new logic that triggers when `isOpen` changes to false)
- This ensures all hooks are called on every render, maintaining the Rules of Hooks compliance

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 59`

🔗 [Edit in Builder.io](https://builder.io/app/projects/8312d9a7546845dfbedcb6cb8756461d/spark-lab)

👀 [Preview Link](https://8312d9a7546845dfbedcb6cb8756461d-spark-lab.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>8312d9a7546845dfbedcb6cb8756461d</projectId>-->
<!--<branchName>spark-lab</branchName>-->